### PR TITLE
Update signup args

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -78,6 +78,8 @@ class TestSignupFunction:
         self.non_admin_key = "non_admin_key"
         self.client_email = "client@email.com"
         self.client_name = "client"
+        self.first_name = "First"
+        self.last_name = "Last"
 
     @patch('willisapi_client.services.auth.login_manager.AuthUtils.signup')
     def test_signup_failed(self, mocked_signup):
@@ -85,7 +87,7 @@ class TestSignupFunction:
             "status_code": 200,
             "message": "Not an admin user"
             }
-        message = create_user(self.non_admin_key, self.client_email, self.client_name)
+        message = create_user(self.non_admin_key, self.client_email, self.client_name, self.first_name, self.last_name)
         assert message == "Not an admin user"
 
     @patch('willisapi_client.services.auth.login_manager.AuthUtils.signup')
@@ -94,7 +96,7 @@ class TestSignupFunction:
             "status_code": 200,
             "message": "User created"
             }
-        message = create_user(self.admin_key, self.client_email, self.client_name)
+        message = create_user(self.admin_key, self.client_email, self.client_name, self.first_name, self.last_name)
         assert message == "User created"
 
     @patch('willisapi_client.services.auth.login_manager.AuthUtils.signup')
@@ -102,7 +104,7 @@ class TestSignupFunction:
         mocked_signup.return_value = {
             "status_code": 400,
             }
-        message = create_user(self.admin_key, self.client_email, self.client_name)
+        message = create_user(self.admin_key, self.client_email, self.client_name, self.first_name, self.last_name)
         assert message == None
 
     @patch('willisapi_client.services.auth.login_manager.AuthUtils.signup')
@@ -110,7 +112,7 @@ class TestSignupFunction:
         mocked_signup.return_value = {
             "status_code": 500,
             }
-        message = create_user(self.admin_key, self.client_email, self.client_name)
+        message = create_user(self.admin_key, self.client_email, self.client_name, self.first_name, self.last_name)
         assert message == None
 
     @patch('willisapi_client.services.auth.login_manager.AuthUtils.signup')
@@ -118,7 +120,7 @@ class TestSignupFunction:
         mocked_signup.return_value = {
             "status_code": 401,
             }
-        message = create_user(self.admin_key, self.client_email, self.client_name)
+        message = create_user(self.admin_key, self.client_email, self.client_name, self.first_name, self.last_name)
         assert message == None
 
     @patch('willisapi_client.services.auth.login_manager.AuthUtils.signup')
@@ -126,5 +128,5 @@ class TestSignupFunction:
         mocked_signup.return_value = {
             "status_code": 403,
             }
-        message = create_user(self.admin_key, self.client_email, self.client_name)
+        message = create_user(self.admin_key, self.client_email, self.client_name, self.first_name, self.last_name)
         assert message == None

--- a/willisapi_client/services/auth/user_manager.py
+++ b/willisapi_client/services/auth/user_manager.py
@@ -5,7 +5,7 @@ from willisapi_client.willisapi_client import WillisapiClient
 from willisapi_client.services.auth.auth_utils import AuthUtils
 from willisapi_client.logging_setup import logger as logger
 
-def create_user(key: str, client_email: str , client_name: str) -> str:
+def create_user(key: str, client_email: str , client_name: str, first_name: str, last_name: str) -> str:
     """
     ---------------------------------------------------------------------------------------------------
     Function: create_user
@@ -17,6 +17,8 @@ def create_user(key: str, client_email: str , client_name: str) -> str:
     key: Admin access token
     client_email: string representation of client email id
     client_name: stringbrepresentation of expected client name without empty spaces
+    first_name: User's first name
+    last_name: User's last_name
 
     Returns:
     ----------
@@ -28,7 +30,7 @@ def create_user(key: str, client_email: str , client_name: str) -> str:
     url = wc.get_signup_url()
     headers = wc.get_headers()
     headers['Authorization'] = key
-    data = dict(client_email=client_email, client_name=client_name)
+    data = dict(client_email=client_email, client_name=client_name, first_name=first_name, last_name=last_name)
     response = AuthUtils.signup(url, data, headers, try_number=1)
     if response and 'status_code' in response and response['status_code'] == HTTPStatus.OK:
         logger.info(f"Signup Successful for client: {client_name}, client_email: {client_email}")


### PR DESCRIPTION
## Description

[Describe the purpose and scope of this pull request.]
Signup function takes two args as of now. client_name and client_email. This PR will allow signup function to take first_name, last_name as well and make a post call to willisAPI signup api.

## Changes Made

[List the changes made in this pull request.]

## Checklist

- [x] followed the coding style guidelines.
- [x] tested all changes.
- [ ] updated the documentation to reflect these changes.
- [x] assigned reviewers to this pull request.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205364620753038
  - https://app.asana.com/0/0/1205326575602720